### PR TITLE
NFSv3 MOUNT protocol EXPORT handler

### DIFF
--- a/lib/mount/export_reply.js
+++ b/lib/mount/export_reply.js
@@ -1,0 +1,120 @@
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+var path = require('path');
+var util = require('util');
+
+var assert = require('assert-plus');
+var clone = require('clone');
+var rpc = require('oncrpc');
+
+
+///--- Globals
+var RpcReply = rpc.RpcReply;
+var XDR = rpc.XDR;
+
+
+///--- Helpers
+
+function calculate_buffer_length(exports) {
+    assert.arrayOfObject(exports, 'exports');
+    var sz = 0;
+    exports.forEach(function (e) {
+        sz += 4; // boolean marker
+        sz += XDR.byteLength(e.dirpath);
+        e.groups.forEach(function (g) {
+            sz += 4; // Optional-Data boolean marker
+            sz += XDR.byteLength(g.name);
+        });
+        sz += 4; // final boolean marker
+    });
+    sz += 4; // final boolean marker
+
+    return (sz);
+}
+
+
+
+///--- API
+
+function MountExportReply(opts) {
+    RpcReply.call(this, opts);
+
+    this.exports = [];
+
+    this._nfs_mount_export_reply = true; // MDB
+}
+util.inherits(MountExportReply, RpcReply);
+
+
+MountExportReply.prototype.addExport = function addExport(opts, noClone) {
+    assert.object(opts);
+    assert.string(opts.dirpath, 'options.dirpath');
+    assert.arrayOfObject(opts.groups, 'options.groups');
+    opts.groups.forEach(function (group) {
+        assert.string(group.name, 'group.name');
+    });
+
+    assert.optionalBool(noClone, 'noClone');
+
+    this.exports.push(noClone ? opts : clone(opts));
+};
+
+
+MountExportReply.prototype._transform = function _transform(chunk, enc, cb) {
+    if (this.incoming) {
+        var xdr = new XDR(chunk);
+
+        while (xdr.readBool()) {
+            var dirpath = xdr.readString();
+            var groups = [];
+            while (xdr.readBool()) {
+                var name = xdr.readString();
+                groups.push(name);
+            }
+            this.addExport({
+                dirpath: dirpath,
+                groupts: groups
+            }, true);
+        }
+    } else {
+        this.push(chunk);
+    }
+
+    cb();
+};
+
+
+MountExportReply.prototype.writeHead = function writeHead() {
+    var len = calculate_buffer_length(this.exports);
+    var xdr = this._serialize(len);
+
+    this.exports.forEach(function (e) {
+        xdr.writeBool(true);
+        xdr.writeString(e.dirpath);
+        e.groups.forEach(function (g) {
+            xdr.writeBool(true);
+            xdr.writeString(g.name);
+        });
+        xdr.writeBool(false);
+    });
+    xdr.writeBool(false);
+
+    this.write(xdr.buffer());
+};
+
+
+MountExportReply.prototype.toString = function toString() {
+    var fmt = '[object MountExportReply <xid=%d, exports=%j>]';
+    return (util.format(fmt, this.xid, this.exports));
+};
+
+
+
+///--- Exports
+
+module.exports = {
+    MountExportReply: MountExportReply
+};

--- a/lib/mount/server.js
+++ b/lib/mount/server.js
@@ -12,6 +12,7 @@ var rpc = require('oncrpc');
 
 var errors = require('./errors');
 var MountDumpReply = require('./dump_reply').MountDumpReply;
+var MountExportReply = require('./export_reply').MountExportReply;
 var MountMntCall = require('./mnt_call').MountMntCall;
 var MountMntReply = require('./mnt_reply').MountMntReply;
 var MountUmntCall = require('./umnt_call').MountUmntCall;
@@ -57,6 +58,17 @@ MountServer.prototype.dump = function dump() {
     return (this);
 };
 
+
+MountServer.prototype.exprt = function exprt() {
+    var cfg = {
+        name: 'export',
+        procedure: 5,
+        reply: MountExportReply
+    };
+    this._mount(cfg, slice(arguments));
+
+    return (this);
+};
 
 
 MountServer.prototype.mnt = function mnt() {

--- a/test/mount.test.js
+++ b/test/mount.test.js
@@ -42,6 +42,19 @@ before(function (cb) {
         next();
     });
 
+    server.exprt(function exprt(req, res, next) {
+        Object.keys(server.mounts).forEach(function (k) {
+            res.addExport({
+                dirpath: k,
+                groups: [{
+                    name: "0.0.0.0/0"
+                }]
+            });
+        });
+        res.send();
+        next();
+    });
+
     server.mnt(function mount(req, res, next) {
         assert.ok(req.dirpath);
         var uuid = libuuid.v4();


### PR DESCRIPTION
This adds support for the NFSv3 [MOUNT EXPORT procedure](https://tools.ietf.org/html/rfc1813#section-5.2.5), so that one can supply a response for `showmount -e <host>`. 

The test code is admittedly a guess as the most recent version of node I've been able to get this module to build against is 0.10.48 which does not play well with the version of nodeunit declared (it appears to use ES6 features not supported in 0.10.x [i.e. `--harmony` wasn't enough]). FWIW, I'm currently using this with a modified version of [https://github.com/joyent/sdc-nfs](joyent/sdc-nfs).

If you happen to know how I can get the module installed such that everything builds and the tests can actually be run, I'd be more than happy to make sure the tests pass (assuming they would have already passed ;).